### PR TITLE
feat: add typography components

### DIFF
--- a/src/components/Text/Text.stories.ts
+++ b/src/components/Text/Text.stories.ts
@@ -1,0 +1,43 @@
+import Text from './TheText.vue'
+
+const meta: Meta<typeof Text> = {
+	component: Text,
+	title: 'Typography/Text',
+	tags: ['autodocs'],
+	argTypes: {
+		default: {
+			control: 'text',
+			description: 'Slot content',
+			defaultValue: 'This is the text'
+		},
+		type: {
+			control: 'radio',
+			description: 'Text type',
+			defaultValue: 'paragraph',
+			options: ['lead', 'large', 'paragraph', 'link', 'small', 'subtitle']
+		}
+	}
+}
+
+const Template = (args: unknown) => ({
+	components: { Text },
+	setup() {
+		return { args }
+	},
+	template: `<Text v-bind="args">{{ args.default }}</Text>`
+})
+
+export const Default = Template.bind({})
+Default.args = {
+	size: 'paragraph',
+	default: 'This is the paragraph'
+}
+
+export const Link = Template.bind({})
+Link.args = {
+	type: 'link',
+	default: 'This is the link',
+	href: '#'
+}
+
+export default meta

--- a/src/components/Text/TheText.vue
+++ b/src/components/Text/TheText.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { cn } from '@/utils'
+import { textVariants, type TextProps } from '.'
+
+const props = defineProps<TextProps>()
+
+const tag = computed(() => {
+	return props.type === 'link' ? 'a' : 'p'
+})
+</script>
+
+<template>
+	<component :is="tag" :class="cn(textVariants({ type }), props.class)"><slot /></component>
+</template>

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,0 +1,27 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import { HTMLAttributes } from 'vue'
+
+export const textVariants = cva('title', {
+	variants: {
+		type: {
+			lead: 'text-xl font-normal',
+			large: 'text-lg font-semibold',
+			paragraph: 'text-base font-medium leading-7',
+			link: 'text-base font-medium leading-7 text-royal-blue-600 transition-all hover:underline',
+			small: 'text-sm font-medium leading-[14px]',
+			subtitle: 'text-sm font-medium leading-[14px] text-fiord-500'
+		}
+	},
+	defaultVariants: {
+		type: 'paragraph'
+	}
+})
+
+type TextVariants = VariantProps<typeof textVariants>
+
+export interface TextProps {
+	type: TextVariants['type']
+	class: HTMLAttributes['class']
+}
+
+export { default as Text } from './TheText.vue'

--- a/src/components/Title/TheTitle.vue
+++ b/src/components/Title/TheTitle.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { cn } from '@/utils'
+import { titleVariants, type TitleProps } from '.'
+
+const props = defineProps<TitleProps>()
+
+const sizes = {
+	large: '1',
+	medium: '2',
+	small: '3',
+	tiny: '4'
+}
+
+const tag = computed(() => {
+	return `h${sizes[props.size]}`
+})
+</script>
+
+<template>
+	<component :is="tag" :class="cn(titleVariants({ size }), props.class)"><slot /></component>
+</template>

--- a/src/components/Title/Title.stories.ts
+++ b/src/components/Title/Title.stories.ts
@@ -1,0 +1,36 @@
+import Title from './TheTitle.vue'
+
+const meta: Meta<typeof Title> = {
+	component: Title,
+	title: 'Typography/Title',
+	tags: ['autodocs'],
+	argTypes: {
+		default: {
+			control: 'text',
+			description: 'Slot content',
+			defaultValue: 'This is the title'
+		},
+		size: {
+			control: 'radio',
+			description: 'Title size',
+			defaultValue: 'large',
+			options: ['large', 'medium', 'small', 'tiny']
+		}
+	}
+}
+
+const Template = (args: unknown) => ({
+	components: { Title },
+	setup() {
+		return { args }
+	},
+	template: `<Title v-bind="args">{{ args.default }}</Title>`
+})
+
+export const Default = Template.bind({})
+Default.args = {
+	size: 'large',
+	default: 'This is the title'
+}
+
+export default meta

--- a/src/components/Title/index.ts
+++ b/src/components/Title/index.ts
@@ -1,0 +1,25 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import { HTMLAttributes } from 'vue'
+
+export const titleVariants = cva('title', {
+	variants: {
+		size: {
+			large: 'tracking-[1.2%]; text-5xl font-extrabold leading-[3rem]',
+			medium: 'text-3xl font-semibold tracking-[0.75%]',
+			small: 'text-2xl font-semibold tracking-[0.8%]',
+			tiny: 'text-xl font-semibold tracking-[0.5%]'
+		}
+	},
+	defaultVariants: {
+		size: 'large'
+	}
+})
+
+type TitleVariants = VariantProps<typeof titleVariants>
+
+export interface TitleProps {
+	size: TitleVariants['size']
+	class: HTMLAttributes['class']
+}
+
+export { default as Title } from './TheTitle.vue'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './Form'
+export * from './Title'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
 		"noFallthroughCasesInSwitch": true,
 		"outDir": "dist",
 		"declaration": false,
-		"baseUrl": "."
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["./src/*"]
+		}
 	},
 	"include": ["src/**/*.ts", "src/**/*.vue"],
 	"references": [{ "path": "./tsconfig.node.json" }],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,5 +30,10 @@ export default defineConfig({
 				}
 			}
 		}
+	},
+	resolve: {
+		alias: {
+			'@': fileURLToPath(new URL('./src', import.meta.url))
+		}
 	}
 })


### PR DESCRIPTION
## Added:

1. Title components (4 different variations)
2. Text component (5 different variations

## Todo:

- [x] Change the component name from `Title` to `Heading`
- [x] Create a separate component `Link` (remove this component from `Text` component